### PR TITLE
좋아요 정렬

### DIFF
--- a/dgufest/templates/shared/gallery_item.html
+++ b/dgufest/templates/shared/gallery_item.html
@@ -3,7 +3,7 @@
         <div class="single-portfolio-content">
             {% if "video" in post.mediatype %}
                 <div id="video-{{post.id}}" style="display: block !important;">
-                    <video class="col-12" controls >
+                    <video class="col-12" controls preload="metadata">
                         <source src="{{post.mediafile.url}}" alt="video">
                     </video>
                 </div>

--- a/posts/templates/posts/gallery.html
+++ b/posts/templates/posts/gallery.html
@@ -76,16 +76,6 @@
             {% endfor %}
         </div>
     </div>
-    <div class="row">
-        <div class="col-12 text-center wow fadeInUp" data-wow-delay="800ms">
-                {% if posts.has_previous %}
-                    <a href="?page={{posts.previous_page_number}}" class="btn alime-btn btn-2 mt-15">Previous</a>
-                {% endif %}
-                {% if posts.has_next %}
-                    <a href="?page={{posts.next_page_number}}" class="btn alime-btn btn-2 mt-15">View More</a>
-                {% endif %} 
-        </div>
-    </div>
 </div>
 <!-- Gallery Area End -->
 

--- a/posts/views.py
+++ b/posts/views.py
@@ -4,19 +4,17 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 import json, pdb
 from django.core.paginator import Paginator
+from django.db.models import Count
 # Create your views here.
 
 def gallery(request):
     posts=Post.objects.all().order_by('-created_at')
     sort = request.GET.get('sort','') 
-    paginator = Paginator(posts, 20)
-    page = request.GET.get('page')
-    posts = paginator.get_page(page)
+    # paginator = Paginator(posts, 50)
+    # page = request.GET.get('page')
+    # posts = paginator.get_page(page)
     if sort == 'random':
         posts=Post.objects.all().order_by('?')
-        # paginator = Paginator(random_posts, 5)
-        # page = request.GET.get('page')
-        # posts = paginator.get_page(page)
     if sort == 'likes':
         posts = Post.objects.all().order_by('-like_user_set')
     return render(request, 'posts/gallery.html', {'posts':posts})


### PR DESCRIPTION
좋아요 순으로 정렬하는 옵션을 추가했습니다.
![image](https://user-images.githubusercontent.com/61783447/94438528-32b2a980-01da-11eb-89db-ab06b585dc8b.png)

페이지 나누기를 시도하였으나 all의 페이지를 이동할 때 주점, 부스, 공연, 기타의 페이지가 같이 넘어가고,
최신순, 랜덤순으로 나누지 못하고 모두 최신순으로 페이지가 넘어가는 문제로 일단 삭제한 상태입니다.
더 고민해보고 추가하겠습니다.