### PR TITLE
navbar 검색 아이콘 삭제

### DIFF
--- a/dgufest/templates/shared/navbar.html
+++ b/dgufest/templates/shared/navbar.html
@@ -52,7 +52,5 @@
         {% endif %}
     </ul>
 
-    <!-- Search Icon -->
-    <div class="search-icon" data-toggle="modal" data-target="#searchModal" style="margin-left:20px"><i class="ti-search"></i></div>
 </div>
 <!-- Nav End -->


### PR DESCRIPTION
navbar의 검색 아이콘을 삭제하였습니다
![화면 캡처 2020-10-01 004134](https://user-images.githubusercontent.com/64943924/94707858-e2c11780-037e-11eb-8e2b-f3af96402761.png)
Resolves #66 