### PR TITLE
내가 쓴 글, 좋아요 누른 글 목록 겹침 해결, 갤러리&마이페이지 배경사진 적용

### DIFF
--- a/posts/templates/posts/gallery.html
+++ b/posts/templates/posts/gallery.html
@@ -5,7 +5,7 @@
 <!-- hover 버튼 위치 -->
 <link rel="stylesheet" href="{% static 'css/style4.css' %}">
 <!-- Breadcrumb Area Start -->
-<section class="breadcrumb-area bg-img bg-overlay jarallax">
+<section class="breadcrumb-area bg-img bg-overlay jarallax" style="background-image: url(/static/img/about-img/aboutimg.jpg);">
     <div class="container h-100">
         <div class="row h-100 align-items-center">
             <div class="col-12">

--- a/users/templates/users/like_list.html
+++ b/users/templates/users/like_list.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <!-- Breadcrumb Area Start -->
-<section class="breadcrumb-area bg-img bg-overlay jarallax">
+<section class="breadcrumb-area bg-img bg-overlay jarallax" style="background-image: url(/static/img/about-img/aboutimg.jpg);">
     <div class="container h-100">
         <div class="row h-100 align-items-center">
             <div class="col-12">

--- a/users/templates/users/mypage.html
+++ b/users/templates/users/mypage.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <!-- Breadcrumb Area Start -->
-<section class="breadcrumb-area bg-img bg-overlay jarallax">
+<section class="breadcrumb-area bg-img bg-overlay jarallax" style="background-image: url(/static/img/about-img/aboutimg.jpg);">
     <div class="container h-100">
         <div class="row h-100 align-items-center">
             <div class="col-12">

--- a/users/templates/users/postlist.html
+++ b/users/templates/users/postlist.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <!-- Breadcrumb Area Start -->
-<section class="breadcrumb-area bg-img bg-overlay jarallax">
+<section class="breadcrumb-area bg-img bg-overlay jarallax" style="background-image: url(/static/img/about-img/aboutimg.jpg);">
     <div class="container h-100">
         <div class="row h-100 align-items-center">
             <div class="col-12">


### PR DESCRIPTION
Fixes : #113
![image](https://user-images.githubusercontent.com/65571623/95014803-52d3e400-0684-11eb-9130-0c8d6c60bcfe.png)
![image](https://user-images.githubusercontent.com/65571623/95014805-57989800-0684-11eb-9c53-609023b7f4dd.png)

겹침 해결했습니다. 디자인은 이렇습니다.

![image](https://user-images.githubusercontent.com/65571623/95014809-667f4a80-0684-11eb-982b-7c6f8343e4dd.png)
이렇게 겹치던게
![image](https://user-images.githubusercontent.com/65571623/95014818-6c752b80-0684-11eb-8d4c-f15a6727e345.png)
겹치치 않지요.